### PR TITLE
Autorecover client tunnel when server is restarted

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm i -g hypershell
 # Create keys
 hypershell-keygen [-f keyfile] [-c comment]
 
-# Create a P2P shell server
+# Create a P2P server
 hypershell-server [-f keyfile] [--firewall filename] [--disable-firewall] [--protocol name]
 
 # Connect to a P2P shell

--- a/bin/client.js
+++ b/bin/client.js
@@ -4,11 +4,14 @@ const path = require('path')
 const fs = require('fs')
 const { Command } = require('commander')
 const Protomux = require('protomux')
+const DHT = require('@hyperswarm/dht')
+const goodbye = require('graceful-goodbye')
 const { SHELLDIR } = require('../constants.js')
 const { ClientSocket } = require('../lib/client-socket.js')
 const { ShellClient } = require('../lib/shell.js')
 const { LocalTunnelClient } = require('../lib/local-tunnel.js')
 const keygen = require('./keygen.js')
+const getKnownPeer = require('../lib/get-known-peer.js')
 
 const program = new Command()
 
@@ -17,9 +20,7 @@ program
   .argument('<server public key or name>', 'Public key or name of the server')
   .option('-f <filename>', 'Filename of the client seed key.', path.join(SHELLDIR, 'peer'))
   .option('-L <[address:]port:host:hostport...>', 'Local port forwarding.')
-  // .option('-R <[address:]port:host:hostport>', 'Remote port forwarding.')
-  // .option('--key <hex or z32>', 'Inline key for the client.')
-  // .option('--connect <server public key>', 'Specifies the filename of the server public key')
+  // .option('--primary-key <hex or z32>', 'Inline primary key for the client.')
   .option('--testnet', 'Use a local testnet.', false)
   .action(cmd)
   .parseAsync()
@@ -32,24 +33,38 @@ async function cmd (serverPublicKey, options = {}) {
   }
 
   if (options.L) {
-    for (const config of options.L) {
-      const { node, socket } = ClientSocket({ keyfile, serverPublicKey, testnet: options.testnet })
-      const mux = new Protomux(socket)
+    // Partially hardcoded "ClientSocket" here as tunnels behaves different, until we can organize better the dht, socket, and mux objects
+    serverPublicKey = getKnownPeer(serverPublicKey)
 
-      const tunnel = new LocalTunnelClient(config, { node, socket, mux })
-      tunnel.open()
+    const seed = Buffer.from(fs.readFileSync(keyfile, 'utf8'), 'hex')
+    const keyPair = DHT.keyPair(seed)
+
+    const node = new DHT({ bootstrap: options.testnet ? [{ host: '127.0.0.1', port: 40838 }] : undefined })
+    goodbye(() => node.destroy(), 2)
+
+    for (const config of options.L) {
+      const tunnel = new LocalTunnelClient(config, { node, keyPair, serverPublicKey })
+      await tunnel.ready()
+
+      goodbye(() => tunnel.close(), 1)
+
+      console.log('Tunnel on TCP', getHost(tunnel.server.address().address) + ':' + tunnel.server.address().port)
     }
     return
-  } else if (options.R) {
-    errorAndExit('-R not supported yet')
-    return
   }
+
+  if (options.R) errorAndExit('-R not supported')
 
   const { node, socket } = ClientSocket({ keyfile, serverPublicKey, testnet: options.testnet })
   const mux = new Protomux(socket)
 
   const shell = new ShellClient(this.rawArgs, { node, socket, mux })
   shell.open()
+}
+
+function getHost (address) {
+  if (address === '::' || address === '0.0.0.0') return 'localhost'
+  return address
 }
 
 function errorAndExit (message) {

--- a/bin/client.js
+++ b/bin/client.js
@@ -34,6 +34,7 @@ async function cmd (serverPublicKey, options = {}) {
 
   if (options.L) {
     // Partially hardcoded "ClientSocket" here as tunnels behaves different, until we can organize better the dht, socket, and mux objects
+
     serverPublicKey = getKnownPeer(serverPublicKey)
 
     const seed = Buffer.from(fs.readFileSync(keyfile, 'utf8'), 'hex')
@@ -50,6 +51,7 @@ async function cmd (serverPublicKey, options = {}) {
 
       console.log('Tunnel on TCP', getHost(tunnel.server.address().address) + ':' + tunnel.server.address().port)
     }
+
     return
   }
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -67,12 +67,11 @@ async function cmd (options = {}) {
   if (protocols === PROTOCOLS) {
     console.log('To connect to this shell, on another computer run:')
     console.log('hypershell ' + keyPair.publicKey.toString('hex'))
-    console.log()
   } else {
     console.log('Running server with restricted protocols')
     console.log('Server key: ' + keyPair.publicKey.toString('hex'))
-    console.log()
   }
+  console.log()
 
   function onFirewall (remotePublicKey, remoteHandshakePayload) {
     if (allowed === true) {

--- a/bin/server.js
+++ b/bin/server.js
@@ -97,7 +97,7 @@ function onconnection ({ protocols, options }, socket) {
   socket.on('end', () => socket.end())
   socket.on('close', () => console.log('Connection closed', socket.remotePublicKey.toString('hex')))
   socket.on('error', function (error) {
-    if (error.code === 'ECONNRESET') return
+    if (error.code === 'ECONNRESET' || error.code === 'ETIMEDOUT') return
     console.error(error.code, error)
   })
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -96,7 +96,10 @@ function onconnection ({ protocols, options }, socket) {
 
   socket.on('end', () => socket.end())
   socket.on('close', () => console.log('Connection closed', socket.remotePublicKey.toString('hex')))
-  socket.on('error', (error) => console.error(error.code, error))
+  socket.on('error', function (error) {
+    if (error.code === 'ECONNRESET') return
+    console.error(error.code, error)
+  })
 
   socket.setKeepAlive(5000)
 

--- a/lib/client-socket.js
+++ b/lib/client-socket.js
@@ -1,9 +1,7 @@
 const fs = require('fs')
-const path = require('path')
 const DHT = require('@hyperswarm/dht')
 const goodbye = require('graceful-goodbye')
-const { SHELLDIR } = require('../constants.js')
-const configs = require('tiny-configs')
+const getKnownPeer = require('./get-known-peer.js')
 
 module.exports = {
   ClientSocket,
@@ -11,7 +9,7 @@ module.exports = {
 }
 
 function ClientSocket ({ keyfile, serverPublicKey, reusableSocket = false, testnet = false }) {
-  serverPublicKey = parseNameOrPublicKey(serverPublicKey)
+  serverPublicKey = getKnownPeer(serverPublicKey)
 
   const seed = Buffer.from(fs.readFileSync(keyfile, 'utf8'), 'hex')
   const keyPair = DHT.keyPair(seed)
@@ -65,34 +63,4 @@ function waitForSocketTermination (socket) {
       resolve()
     }
   })
-}
-
-function parseNameOrPublicKey (host) {
-  for (const peer of readKnownPeers()) {
-    if (peer.name === host) {
-      host = peer.publicKey
-      break
-    }
-  }
-
-  return Buffer.from(host, 'hex')
-}
-
-function readKnownPeers () {
-  const filename = path.join(SHELLDIR, 'known_peers')
-
-  if (!fs.existsSync(filename)) {
-    // console.log('Notice: creating default known peers', filename)
-    fs.mkdirSync(path.dirname(filename), { recursive: true })
-    fs.writeFileSync(filename, '# <name> <public key>\n', { flag: 'wx' })
-  }
-
-  try {
-    const file = fs.readFileSync(filename, 'utf8')
-    return configs.parse(file, { split: ' ', length: 2 })
-      .map(m => ({ name: m[0], publicKey: m[1] }))
-  } catch (error) {
-    if (error.code === 'ENOENT') return []
-    throw error
-  }
 }

--- a/lib/get-known-peer.js
+++ b/lib/get-known-peer.js
@@ -1,0 +1,34 @@
+const fs = require('fs')
+const path = require('path')
+const configs = require('tiny-configs')
+const { SHELLDIR } = require('../constants.js')
+
+module.exports = function getKnownPeer (host) {
+  for (const peer of readKnownPeers()) {
+    if (peer.name === host) {
+      host = peer.publicKey
+      break
+    }
+  }
+
+  return Buffer.from(host, 'hex')
+}
+
+function readKnownPeers () {
+  const filename = path.join(SHELLDIR, 'known_peers')
+
+  if (!fs.existsSync(filename)) {
+    // console.log('Notice: creating default known peers', filename)
+    fs.mkdirSync(path.dirname(filename), { recursive: true })
+    fs.writeFileSync(filename, '# <name> <public key>\n', { flag: 'wx' })
+  }
+
+  try {
+    const file = fs.readFileSync(filename, 'utf8')
+    return configs.parse(file, { split: ' ', length: 2 })
+      .map(m => ({ name: m[0], publicKey: m[1] }))
+  } catch (error) {
+    if (error.code === 'ENOENT') return []
+    throw error
+  }
+}

--- a/lib/local-tunnel.js
+++ b/lib/local-tunnel.js
@@ -170,7 +170,7 @@ class LocalTunnelClient extends ReadyResource {
   }
 
   onopen () {
-    // No-op for now
+    // No-op
   }
 
   onclose () {

--- a/lib/local-tunnel.js
+++ b/lib/local-tunnel.js
@@ -2,7 +2,10 @@ const net = require('net')
 const c = require('compact-encoding')
 const pump = require('pump')
 const DHT = require('@hyperswarm/dht')
+const Protomux = require('protomux')
 const SecretStream = require('@hyperswarm/secret-stream')
+const ReadyResource = require('ready-resource')
+const safetyCatch = require('safety-catch')
 
 class LocalTunnelServer {
   constructor ({ node, socket, mux, options }) {
@@ -54,11 +57,15 @@ class LocalTunnelServer {
     const rawStream = this.dht.createRawStream()
     this.streams.set(rawStream.id, rawStream)
     rawStream.on('close', () => this.streams.delete(rawStream.id))
+    rawStream.on('error', safetyCatch)
 
     c.messages[0].send({ clientId, serverId: rawStream.id })
 
     DHT.connectRawStream(this.socket, rawStream, clientId)
     const secretStream = new SecretStream(true, rawStream)
+    secretStream.on('error', safetyCatch)
+
+    secretStream.setKeepAlive(5000)
 
     const remoteSocket = net.connect(this.config.port, this.config.host)
     rawStream.userData = { remoteSocket, secretStream }
@@ -102,14 +109,50 @@ class LocalTunnelServer {
   }
 }
 
-class LocalTunnelClient {
-  constructor (config, { node, socket, mux }) {
+class LocalTunnelClient extends ReadyResource {
+  constructor (config, { node, keyPair, serverPublicKey }) {
+    super()
+
     this.dht = node
-    this.socket = socket
+
+    this.keyPair = keyPair
+    this.serverPublicKey = serverPublicKey
 
     this.config = LocalTunnelClient.parse(config) // + defaults
 
-    this.channel = mux.createChannel({
+    this.streams = new Map()
+    this.server = net.createServer(this.onconnection.bind(this)) // + option for udp
+
+    this.ready().catch(safetyCatch)
+  }
+
+  async _open () {
+    this.server.listen(this.config.local.port, this.config.local.host)
+
+    await waitForServer(this.server)
+  }
+
+  _close () {
+    this.server.close()
+
+    if (this.mux) this.mux.destroy()
+  }
+
+  _createMux () {
+    if (this.mux && !this.mux.stream.destroying) return
+
+    // + reusableSocket for when having several -L tunnels?
+    const socket = this.dht.connect(this.serverPublicKey, { keyPair: this.keyPair })
+
+    socket.setKeepAlive(5000)
+
+    this.mux = new Protomux(socket)
+  }
+
+  _createChannel () {
+    if (this.mux.opened({ protocol: 'hypershell-tunnel-local', id: null })) return
+
+    const channel = this.mux.createChannel({
       protocol: 'hypershell-tunnel-local',
       id: null,
       handshake: c.json,
@@ -120,45 +163,36 @@ class LocalTunnelClient {
       onclose: this.onclose.bind(this)
     })
 
-    this.streams = new Map()
-    this.server = net.createServer(this.onconnection.bind(this)) // + option for udp
-    this.ready = null
-  }
+    if (channel === null) return
 
-  open () {
+    this.channel = channel
     this.channel.open(this.config.remote)
   }
 
   onopen () {
-    this.server.listen(this.config.local.port, this.config.local.host)
-    this.ready = waitForServer(this.server) // + try same port error
-
-    this.ready.catch((err) => {
-      console.error(err)
-      this.channel.close()
-    })
+    // No-op for now
   }
 
-  async onclose () {
-    this.socket.end()
-
-    await this.ready
-    if (this.server.listening) this.server.close()
-
+  onclose () {
     for (const [, stream] of this.streams) {
       stream.destroy()
     }
   }
 
   onconnection (localSocket) {
+    this._createMux()
+    this._createChannel()
+
     const rawStream = this.dht.createRawStream()
     this.streams.set(rawStream.id, rawStream)
     rawStream.on('close', () => this.streams.delete(rawStream.id))
-
-    this.channel.messages[0].send({ clientId: rawStream.id, serverId: 0 })
+    rawStream.on('error', safetyCatch)
 
     rawStream.userData = { localSocket }
     rawStream.on('close', () => localSocket.destroy())
+    localSocket.on('error', safetyCatch)
+
+    this.channel.messages[0].send({ clientId: rawStream.id, serverId: 0 })
   }
 
   onstreamid (data, channel) {
@@ -168,8 +202,11 @@ class LocalTunnelClient {
     if (!rawStream) throw new Error('Stream not found: ' + clientId)
     const { localSocket } = rawStream.userData
 
-    DHT.connectRawStream(this.socket, rawStream, serverId)
+    DHT.connectRawStream(this.mux.stream, rawStream, serverId)
     const secretStream = new SecretStream(false, rawStream)
+    secretStream.on('error', safetyCatch)
+
+    secretStream.setKeepAlive(5000)
 
     rawStream.userData.secretStream = secretStream
 
@@ -178,6 +215,7 @@ class LocalTunnelClient {
 
   static parse (config) {
     const match = config.match(/(?:(.*):)?([\d]+):(?:(.*):)?([\d]+)/i)
+
     // + should return errors
     if (!match[2]) errorAndExit('local port is required')
     if (!match[3]) errorAndExit('remote host is required')

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "protomux": "^3.4.0",
     "pump": "^3.0.0",
     "read-file-live": "^1.0.1",
+    "ready-resource": "^1.0.0",
+    "safety-catch": "^1.0.2",
     "tar-fs": "^2.1.1",
     "tiny-configs": "^1.1.0",
     "tt-native": "^1.0.2"


### PR DESCRIPTION
The previous behaviour was:

You run a server like: `hypershell-server`
You run a client like: `hypershell home -L 127.0.0.1:2020:127.0.0.1:3000`

So you have the local tunnel proxy working at `127.0.0.1:2020`, all good until the server gets restarted i.e. by reboot or anything, which triggers the graceful socket ending, meaning the client process also ends up exiting!

For a shell makes total sense that the client also exits, but not for tunnels

So now, when the server gets restarted or offline for some reason: the client will get all streams destroyed or time out, but the process will continue running as nothing more happened, and when trying to make a new connection it will respectively try to reconnect to the server, etc