### PR TITLE
600 permission for private key

### DIFF
--- a/bin/keygen.js
+++ b/bin/keygen.js
@@ -52,7 +52,7 @@ async function cmd (options = {}) {
 
   const seed = Keychain.seed()
   fs.mkdirSync(path.dirname(keyfile), { recursive: true })
-  fs.writeFileSync(keyfile, seed.toString('hex') + comment + '\n', { flag: 'wx' })
+  fs.writeFileSync(keyfile, seed.toString('hex') + comment + '\n', { flag: 'wx', mode: '600' })
 
   console.log('Your key has been saved in', keyfile)
   console.log('The public key is:')

--- a/test/basic.js
+++ b/test/basic.js
@@ -24,9 +24,9 @@ test('keygen', async function (t) {
     if (process.platform === 'win32') {
       t.pass('No user-specific file permissions on windows')
     } else {
-      const mode = fs.statSync(keyfile).mode.toString(8) // byte repr
+      const mode = fs.statSync(keyfile).mode.toString(8)
       const permissions = mode.slice(-3)
-      t.is(permissions, '600') // Only user can access
+      t.is(permissions, '600')
     }
   })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -25,7 +25,7 @@ test('keygen', async function (t) {
       t.pass('No user-specific file permissions on windows')
     } else {
       const mode = fs.statSync(keyfile).mode.toString(8) // byte repr
-      const permissions = mode.slice(mode.length - 3)
+      const permissions = mode.slice(-3)
       t.is(permissions, '600') // Only user can access
     }
   })

--- a/test/basic.js
+++ b/test/basic.js
@@ -21,9 +21,13 @@ test('keygen', async function (t) {
 
   keygen.on('close', () => {
     t.ok(fs.existsSync(keyfile))
-    const mode = fs.statSync(keyfile).mode.toString(8) // byte repr
-    const permissions = mode.slice(mode.length - 3)
-    t.is(permissions, '600') // Only user can access
+    if (process.platform === 'win32') {
+      t.pass('No user-specific file permissions on windows')
+    } else {
+      const mode = fs.statSync(keyfile).mode.toString(8) // byte repr
+      const permissions = mode.slice(mode.length - 3)
+      t.is(permissions, '600') // Only user can access
+    }
   })
 
   await waitForProcess(keygen)


### PR DESCRIPTION
The 'peer' file is the equivalent of an ssh private key, so better not to give the full system read access