### PR TITLE
ctrl-c fix

### DIFF
--- a/lib/shell.js
+++ b/lib/shell.js
@@ -124,6 +124,12 @@ class ShellClient {
   }
 
   onstdin (data) {
+    if (data.length === 1 && data[0] === 3) {
+      this.channel.messages[3].send(0)
+      this.channel.messages[2].send(Buffer.from('\nCtrl^C\n'))
+      this.destroy()
+      return
+    }
     this.channel.messages[0].send(data)
   }
 
@@ -153,6 +159,11 @@ class ShellClient {
     this.socket.removeListener('close', this.onsocketclose)
 
     process.stdin.pause() // + process.exit()?
+  }
+
+  destroy () {
+    this.channel.close()
+    this.socket.destroy()
   }
 
   static parseVariadic (rawArgs) {


### PR DESCRIPTION
todo: needs to be able to propagate so that if a program is in foreground in hypershell it gets the ctrl+c signal on the server end OR close in favour of a solution in tt-native