### PR TITLE
Unflake tests: pass in testnet port to CLI

### DIFF
--- a/bin/copy.js
+++ b/bin/copy.js
@@ -20,7 +20,7 @@ program
   .argument('<target>', 'Target')
   .option('-f <filename>', 'Filename of the client seed key.', path.join(SHELLDIR, 'peer'))
   // .option('--key <hex or z32>', 'Inline key for the client.')
-  .option('--testnet', 'Use a local testnet.', false)
+  .option('--testnet <number>', 'Use a local testnet.', parseInt)
   .action(cmd)
   .parseAsync()
 
@@ -44,7 +44,12 @@ async function cmd (sourcePath, targetPath, options = {}) {
     errorAndExit('Invalid source or target path.')
   }
 
-  const { node, socket } = ClientSocket({ keyfile, serverPublicKey, testnet: options.testnet })
+  let bootstrap = null
+  if (options.testnet != null) {
+    bootstrap = [{ host: '127.0.0.1', port: options.testnet }]
+  }
+
+  const { node, socket } = ClientSocket({ keyfile, serverPublicKey, bootstrap })
   const mux = new Protomux(socket)
 
   if (fileOperation === 'upload') {

--- a/bin/server.js
+++ b/bin/server.js
@@ -30,7 +30,7 @@ program
   .option('--protocol <name...>', 'List of allowed protocols.')
   .option('--tunnel-host <address...>', 'Restrict tunneling to a limited set of hosts.')
   .option('--tunnel-port <port...>', 'Restrict tunneling to a limited set of ports.')
-  .option('--testnet', 'Use a local testnet.', false)
+  .option('--testnet <number>', 'Use a local testnet at the specified port.', parseInt)
   .action(cmd)
   .parseAsync()
 
@@ -54,7 +54,12 @@ async function cmd (options = {}) {
   const seed = HypercoreId.decode(fs.readFileSync(keyfile, 'utf8').trim())
   const keyPair = DHT.keyPair(seed)
 
-  const node = new DHT({ bootstrap: options.testnet ? [{ host: '127.0.0.1', port: 40838 }] : undefined })
+  let bootstrap = null
+  if (options.testnet) {
+    bootstrap = [{ host: '127.0.0.1', port: options.testnet }]
+  }
+
+  const node = new DHT({ bootstrap })
   goodbye(() => node.destroy(), 3)
 
   const server = node.createServer({ firewall: onFirewall })

--- a/lib/client-socket.js
+++ b/lib/client-socket.js
@@ -9,13 +9,13 @@ module.exports = {
   waitForSocketTermination
 }
 
-function ClientSocket ({ keyfile, serverPublicKey, reusableSocket = false, testnet = false }) {
+function ClientSocket ({ keyfile, serverPublicKey, reusableSocket = false, bootstrap }) {
   serverPublicKey = getKnownPeer(serverPublicKey)
 
   const seed = HypercoreId.decode(fs.readFileSync(keyfile, 'utf8').trim())
   const keyPair = DHT.keyPair(seed)
 
-  const node = new DHT({ bootstrap: testnet ? [{ host: '127.0.0.1', port: 40838 }] : undefined })
+  const node = new DHT({ bootstrap })
   const unregisterNode = goodbye(() => node.destroy(), 2)
 
   const socket = node.connect(serverPublicKey, { keyPair, reusableSocket })


### PR DESCRIPTION
Previous approach was to hard-code the port and pass in a boolean flag, but that fails when that port is already in use. This approach passes in an integer flag specifying the port number where the testnet bootstrap runs, which always works.
